### PR TITLE
Reference-based deconstruction of backends via weak_ptr

### DIFF
--- a/src/ngraph_graph.cc
+++ b/src/ngraph_graph.cc
@@ -23,6 +23,7 @@
 
 namespace ngraph_bridge {
 
+std::mutex backends_mutex;
 std::unordered_map<std::string, std::weak_ptr<ngraph::runtime::Backend>>
     backends;
 

--- a/src/ngraph_graph.cc
+++ b/src/ngraph_graph.cc
@@ -23,7 +23,7 @@
 
 namespace ngraph_bridge {
 
-std::unordered_map<std::string, std::shared_ptr<ngraph::runtime::Backend>>
+std::unordered_map<std::string, std::weak_ptr<ngraph::runtime::Backend>>
     backends;
 
 /**

--- a/src/ngraph_nnvm_ops.cc
+++ b/src/ngraph_nnvm_ops.cc
@@ -87,7 +87,7 @@ void compute_forward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
                      const std::vector<mxnet::NDArray> &inputs,
                      const std::vector<mxnet::OpReqType> &req,
                      const std::vector<mxnet::NDArray> &outputs) {
-  auto backend = GetBackendFromContext(graph->context_);
+  auto backend = graph->get_backend();
   auto placeholders =
       get_tensor_views(inputs, backend, nullptr, graph->is_reuse_mem);
   // for outputs we need to comply with req
@@ -127,7 +127,7 @@ void compute_backward(const mxnet::OpContext &ctx, std::shared_ptr<Graph> graph,
                       const std::vector<mxnet::OpReqType> &req,
                       const std::vector<mxnet::NDArray> &outputs) {
   // only expect backward is called in training mode
-  auto backend = GetBackendFromContext(graph->context_);
+  auto backend = graph->get_backend();
 
   const int mode = static_cast<int>(GraphExeMode::kTrain);
   compile_if_needed(graph, mode);

--- a/src/ngraph_sgcompiler.cc
+++ b/src/ngraph_sgcompiler.cc
@@ -42,7 +42,7 @@ void CompileForward(std::shared_ptr<Graph> sub_graph,
                     GraphExeMode exe_mode) {
   const int mode = static_cast<int>(exe_mode);
 
-  auto backend = GetBackendFromContext(sub_graph->context_);
+  auto backend = sub_graph->get_backend();
 
   // Log the graph so Graph_* corresponds to Function_* in codgen
   if (ngraph_log_graph()) {
@@ -70,7 +70,7 @@ void CompileForwardBackward(std::shared_ptr<Graph> sub_graph,
                             const ngraph::FpropCache &fprop_cache) {
   const int mode = static_cast<int>(exe_mode);
 
-  auto backend = GetBackendFromContext(sub_graph->context_);
+  auto backend = sub_graph->get_backend();
 
   // clone the functions to ensure we don't have
   // any repeated nodes between graphs
@@ -201,7 +201,7 @@ std::shared_ptr<ngraph::Function> SGCompiler::MakeForwardFunction(
     outputs.push_back(op_map_.at(output));
   }
 
-  auto backend = GetBackendFromContext(sub_graph->context_);
+  auto backend = sub_graph->get_backend();
 
   // push additional aux outputs
   if (!aux_op_map_.empty()) {
@@ -307,7 +307,8 @@ std::shared_ptr<ngraph::Function> SGCompiler::MakeBackwardFunction(
 
 // Compile a Subgraph into ngraph forward and backward call frames
 void SGCompiler::CompileSubgraph(std::shared_ptr<Graph> sub_graph) {
-  auto backend = GetBackendFromContext(sub_graph->context_);
+  auto backend = sub_graph->get_backend();
+
 
   // initalize a placeholder order vector for this subgraph
   for (auto i : sub_graph->inputs_) placeholder_order_.push_back(i);

--- a/src/ngraph_stats.cc
+++ b/src/ngraph_stats.cc
@@ -46,7 +46,7 @@ void NGraphStats::dump(std::ostream& out) {
       if (g) {
         out << std::string(total_column_, '#') << "\n";
         out << "# Graph " << g->name_ << std::endl;
-        auto backend = GetBackendFromContext(g->context_);
+        auto backend = g->get_backend();
 
         auto print_perf_for_pass = [&](
             const std::shared_ptr<ngraph::Function>& func,


### PR DESCRIPTION
Switch backends map to use a std::weak_ptr and add backend member to ngraph_bridge::Graph, then rely on the std::shared_ptr reference count to determine when backend deconstruction should occur.