### PR TITLE
clean up graph references properly

### DIFF
--- a/src/ngraph_compiler.cc
+++ b/src/ngraph_compiler.cc
@@ -210,13 +210,20 @@ Compiler::Compiler(const nnvm::Graph& graph, const NDArrayMap& feed_dict,
   ProcessGraph(feed_dict);
 }
 
+
 void Compiler::ReshapeGraph(const nnvm::ShapeVector& new_shapes) {
-  sub_ngraph_ = nullptr;
+  std::unordered_set<NodePtr> visited;
+  ngraph_.clear_nodes(visited);
+  sub_ngraph_->clear_nodes(visited);
+  compiled_nodes_.clear();
+  visited.clear();
+
   for (size_t i = 0; i < new_shapes.size(); ++i) {
     shapes_[i] = new_shapes[i];
   }
-  ngraph_.nodes_.clear();
-  ngraph_.entry_map_.clear();
+
+  sub_ngraph_ = nullptr;
+
   nnvm::Graph graph;
   graph.outputs = graph_.outputs;
 
@@ -435,6 +442,7 @@ void Compiler::CleanUpUneededReferences() {
     kv.first->nodes_.clear();
     kv.first->entry_map_.clear();
   }
+
 }
 
 // assumes there is only one ngraph

--- a/src/ngraph_graph.cc
+++ b/src/ngraph_graph.cc
@@ -519,4 +519,40 @@ void Node::printOpDetails(std::ostream& os) {
   }
 }
 
+void Graph::clear_nodes(std::unordered_set<NodePtr>& visited) {
+  GraphVisitor visitor;
+
+  visitor.operation = [&visited](NodePtr node) {
+    visited.insert(node);
+    if (node->type_ == NodeType::kGraph) {
+      std::static_pointer_cast<Graph>(node)->clear_nodes(visited);
+    } else {
+      node->inputs_.clear();
+    }
+  };
+  visitor.stop_condition = [&visited](NodePtr node, NodePtr input) {
+    if (!(visited.count(input))) {
+      return false;
+    }
+    return true;
+  };
+
+  for (auto& node : inputs_) {
+    GraphTraverse(node, visitor);
+  }
+  inputs_.clear();
+  for (auto& node : nodes_) {
+    GraphTraverse(node, visitor);
+  }
+  nodes_.clear();
+  for (auto& node : output_elements_) {
+    GraphTraverse(node, visitor);
+  }
+  output_elements_.clear();
+  for (auto& node : outputs_) {
+    GraphTraverse(node, visitor);
+  }
+  outputs_.clear();
+}
+
 }  // namespace ngraph_bridge

--- a/src/ngraph_graph.h
+++ b/src/ngraph_graph.h
@@ -281,6 +281,7 @@ class Graph : public Node {
     }
   }
 
+  void clear_nodes(std::unordered_set<NodePtr> &visited);
   std::shared_ptr<ngraph::runtime::Backend> backend;
 
   bool forward_train_computed{false};


### PR DESCRIPTION
fixes the *RCNN memory leaks